### PR TITLE
allow to convert internal book to binary form.

### DIFF
--- a/sources/buildme_mingw_book.sh
+++ b/sources/buildme_mingw_book.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+gcc -O -march=core2 -fno-stack-protector -fno-exceptions -DBOOKGEN -DNDEBUG -DNO_THREADS -D_FORTIFY_SOURCE=0 src/*.cpp -static -o rodent_$MSYSTEM_CARCH.exe
+
+echo quit | ./rodent_$MSYSTEM_CARCH.exe
+
+gcc -Ofast -s -march=core2 -fno-stack-protector -fno-exceptions -DUSEGEN -I . -DNO_THREADS -D_FORTIFY_SOURCE=0 src/*.cpp -static -o rodent_$MSYSTEM_CARCH.exe

--- a/sources/src/main.cpp
+++ b/sources/src/main.cpp
@@ -29,7 +29,13 @@ cMask Mask;
 cDistance Dist;
 sBook GuideBook;
 sBook MainBook;
+
+#ifndef USEGEN
 sInternalBook InternalBook;
+#else
+  #include <book_gen.h>
+#endif
+
 
 int main() {
 

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -72,6 +72,7 @@ enum eSquare {
 
 #if __cplusplus >= 201103L
     #include <cstdint>
+    #include <cinttypes>
     typedef uint64_t U64;
 #else
     typedef unsigned long long U64;
@@ -533,23 +534,48 @@ public:
 
 extern cGlobals Glob;
 
-struct sBookEntry {
-	U64 hash;
-	int move;
-	int freq;
-};
+#ifdef USEGEN
+  #define GIMMESIZE
+  #include <book_gen.h>
+  #undef GIMMESIZE
+#endif
+
+#ifdef PACKSTRUCT
+	#pragma pack(push, 1)
+	struct sBookEntry {
+		U64 hash;
+		uint16_t move;
+		int16_t freq;
+	};
+	#pragma pack(pop)
+#else
+	struct sBookEntry {
+		U64 hash;
+		int move;
+		int freq;
+	};
+#endif
 
 struct sInternalBook {
 public:
-	int n_of_choices;
 	int n_of_records;
-	int moves[100];
-	int values[100];
+
+#ifdef USEGEN
+	sBookEntry internal_book[BOOKSIZE];
+#else
 	sBookEntry internal_book[48000];
+#endif
+
+	int n_of_choices;
+	int moves[100];
+	//int values[100];
+
 	void Init(POS * p);
 	int MoveFromInternal(POS *p);
+#ifndef USEGEN
 	void MoveToInternal(U64 hashKey, int move, int val);
 	int LineToInternal(POS *p, const char *ptr, int excludedColor);
+#endif
 	void ReadInternal(POS *p);
 };
 

--- a/sources/src/uci_options.cpp
+++ b/sources/src/uci_options.cpp
@@ -335,9 +335,7 @@ void ParseSetoption(const char *ptr) {
 	Par.hist_limit = -MAX_HIST + ((MAX_HIST * Par.hist_perc) / 100);
 	Glob.should_clear = 1;
   } else if (strcmp(name, "PersonalityFile") == 0 || strcmp(name, "personalityfile") == 0) {
-	 printf("info string reading ");
-	 printf(value);
-	 printf("\n");
+	 printf("info string reading %s\n", value);
 	 ReadPersonality(value);
   }
 }


### PR DESCRIPTION
This one is slightly more complicated. It can be useful for final release versions. It helps to produce executable that starts faster (really noticeable on old hardware) and slightly smaller.

With the **BOOKGEN** define the produced executable generates *book_gen.h* that looks like this

```c++
#ifndef GIMMESIZE
sInternalBook InternalBook = {
18947,
{
{0x6214e4dd25c8a0b1,  1153, -200}, {0xf79c92ab4c7e6b6d, 14579,    2}, {0x704b3da66306b102,  1350,    1},
{0x073efd3d588c728e,  2942,    1}, {0xb65a71234c2ca182, 14027,    1}, {0xadedf8223155afed,  2998,    1},
{0x137b6f0df431767a,  1858,    1}, {0x9b0ff885d027a3fa,  3517,    1}, {0x2b17e0786b5974de,  1292,    1},
{0x456c5e625e8cd149,  8124,    1}, {0x9ec60bb9824b38c2,   773,    1}, {0xa7946b4781e6e934, 14514,    1},
{0x704b3da66306b102, 14092,    1}, {0xab5bd658f22f2e4d,  2738,    1}, {0xc0b100723c3ba51a, 14027,    2},
{0xdb0689734142ab75,  1827,   53}, {0x28cc763dec87a397,  1810,   53}, {0x3d3fb8a98d1c776c,  3321,   23},

[...]

{0x65e76b6170800817,  1358,    1}, {0x38f4d73eb5344c83,  2022,    1}, {0xd60c8e398fc222fd,  1153,    1},
{0x4384f84fe674e921,  2942,    1}, {0xf2e07451f2d43a2d, 14092,    1}, {0x29f09faf63fda562,  2237,    1},
{0x4844f91ad45a57a2,   771,    1}, {0xe959f2c14474d9ea,  2745,    1}
}
};
#else
#define BOOKSIZE 18947
#define PACKSTRUCT
#endif
```

With the **USEGEN** define it uses the generated header file during compilation.

New included script for msys2 *buildme_mingw_book.sh* can perform these steps automatically.

If neither **BOOKGEN** nor **USEGEN** are defined then the engine behavior will not change.