### PR TITLE
Aliases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.{cpp,h}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/personalities/league/theresa.txt
+++ b/personalities/league/theresa.txt
@@ -45,8 +45,8 @@ setoption name IsolatedOnOpenMg value -10
 setoption name BackwardPawnMg value -8
 setoption name BackwardPawnEg value -10
 setoption name BackwardOnOpenMg value -8
-settoption name PstStyle value 0
-seoption name MobilityStyle value 0
+setoption name PstStyle value 0
+setoption name MobilityStyle value 0
 setoption name NpsLimit value 5500
 setoption name EvalBlur value 0
 setoption name Contempt value 0

--- a/sources/src/main.cpp
+++ b/sources/src/main.cpp
@@ -109,6 +109,7 @@ void cGlobals::Init() {
     reading_personality = false;
     use_personality_files = false;
     separate_books = false;
+    show_pers_file = true;
     thread_no = 1;
 
     // Clearing  and  setting threads  may  be  necessary

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -726,12 +726,12 @@ class cEngine {
     extern cEngine EngineSingle;
 #endif
 
-#define ALIASLEN 12
-#define PATHLEN 240
-#define MAXALIASES 100
+#define PERSALIAS_ALEN       32
+#define PERSALIAS_PLEN       200
+#define PERSALIAS_MAXALIASES 100
 struct sPersAliases {
-    char alias[MAXALIASES][ALIASLEN];
-    char path[MAXALIASES][PATHLEN];
+    char alias[PERSALIAS_MAXALIASES][PERSALIAS_ALEN];
+    char path[PERSALIAS_MAXALIASES][PERSALIAS_PLEN];
     int count;
 };
 

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -553,6 +553,7 @@ class cGlobals {
     bool should_clear;
     bool goodbye;
     bool use_personality_files;
+    bool show_pers_file;
     glob_int depth_reached;
     int moves_from_start; // to restrict book depth for weaker levels
     int thread_no;

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -726,6 +726,15 @@ class cEngine {
     extern cEngine EngineSingle;
 #endif
 
+#define ALIASLEN 12
+#define PATHLEN 240
+#define MAXALIASES 100
+struct sPersAliases {
+    char alias[MAXALIASES][ALIASLEN];
+    char path[MAXALIASES][PATHLEN];
+    int count;
+};
+
 void InitSearch();
 int BulletCorrection(int time);
 int Clip(int sc, int lim);
@@ -786,6 +795,8 @@ extern int move_time;
 extern int move_nodes;
 extern int search_depth;
 extern int start_time;
+
+extern sPersAliases pers_aliases;
 
 extern unsigned int tt_size;
 extern unsigned int tt_mask;

--- a/sources/src/uci.cpp
+++ b/sources/src/uci.cpp
@@ -226,7 +226,7 @@ void SetMoveTime(int base, int inc, int movestogo) {
 void ParseGo(POS *p, const char *ptr) {
 
     char token[80], bestmove_str[6];
-    int wtime, btime, winc, binc, movestogo, strict_time;
+    int wtime, btime, winc, binc, movestogo; bool strict_time;
     int pvb;
 
     move_time = -1;
@@ -237,7 +237,7 @@ void ParseGo(POS *p, const char *ptr) {
     winc = 0;
     binc = 0;
     movestogo = 40;
-    strict_time = 0;
+    strict_time = false;
     search_depth = 64;
     Par.shut_up = false;
 
@@ -245,31 +245,31 @@ void ParseGo(POS *p, const char *ptr) {
         ptr = ParseToken(ptr, token);
         if (*token == '\0')
             break;
-        if (strcmp(token, "ponder") == 0) {
+        if (strcmp(token, "ponder") == 0)           {
             Glob.pondering = true;
-        } else if (strcmp(token, "depth") == 0) {
+        } else if (strcmp(token, "depth") == 0)     {
             ptr = ParseToken(ptr, token);
             search_depth = atoi(token);
-            strict_time = 1;
-        } else if (strcmp(token, "movetime") == 0) {
+            strict_time = true;
+        } else if (strcmp(token, "movetime") == 0)  {
             ptr = ParseToken(ptr, token);
             move_time = atoi(token);
-            strict_time = 1;
-        } else if (strcmp(token, "nodes") == 0) {
+            strict_time = true;
+        } else if (strcmp(token, "nodes") == 0)     {
             ptr = ParseToken(ptr, token);
             move_nodes = atoi(token);
             move_time = 99999999;
-            strict_time = 1;
-        } else if (strcmp(token, "wtime") == 0) {
+            strict_time = true;
+        } else if (strcmp(token, "wtime") == 0)     {
             ptr = ParseToken(ptr, token);
             wtime = atoi(token);
-        } else if (strcmp(token, "btime") == 0) {
+        } else if (strcmp(token, "btime") == 0)     {
             ptr = ParseToken(ptr, token);
             btime = atoi(token);
-        } else if (strcmp(token, "winc") == 0) {
+        } else if (strcmp(token, "winc") == 0)      {
             ptr = ParseToken(ptr, token);
             winc = atoi(token);
-        } else if (strcmp(token, "binc") == 0) {
+        } else if (strcmp(token, "binc") == 0)      {
             ptr = ParseToken(ptr, token);
             binc = atoi(token);
         } else if (strcmp(token, "movestogo") == 0) {

--- a/sources/src/uci.cpp
+++ b/sources/src/uci.cpp
@@ -65,21 +65,7 @@ void UciLoop() {
         ReadLine(command, sizeof(command));
         ptr = ParseToken(command, token);
 
-        // boolean option: strength limit
-
-        if (strstr(command, "setoption name UCI_LimitStrength value"))
-            Par.fl_weakening = (strstr(command, "value true") != 0);
-        if (strstr(command, "setoption name uci_limitstrength value"))
-            Par.fl_weakening = (strstr(command, "value true") != 0);
-
-        // boolean option: opening book usage
-
-        if (strstr(command, "setoption name UseBook value"))
-            Par.use_book = (strstr(command, "value true") != 0);
-        if (strstr(command, "setoption name usebook value"))
-            Par.use_book = (strstr(command, "value true") != 0);
-
-        if (strcmp(token, "uci") == 0) {
+        if (strcmp(token, "uci") == 0)               {
             printf("id name Rodent III 0.200\n");
             Glob.is_console = false;
             printf("id author Pawel Koziol (based on Sungorus 1.4 by Pablo Vazquez)\n");
@@ -88,38 +74,38 @@ void UciLoop() {
         } else if (strcmp(token, "ucinewgame") == 0) {
             ClearTrans();
             Glob.ClearData();
-        } else if (strcmp(token, "isready") == 0) {
+        } else if (strcmp(token, "isready") == 0)    {
             printf("readyok\n");
-        } else if (strcmp(token, "setoption") == 0) {
+        } else if (strcmp(token, "setoption") == 0)  {
             ParseSetoption(ptr);
-        } else if (strcmp(token, "so") == 0) {
+        } else if (strcmp(token, "so") == 0)         {
             ParseSetoption(ptr);
-        } else if (strcmp(token, "position") == 0) {
+        } else if (strcmp(token, "position") == 0)   {
             ParsePosition(p, ptr);
-        } else if (strcmp(token, "go") == 0) {
+        } else if (strcmp(token, "go") == 0)         {
             ParseGo(p, ptr);
-        } else if (strcmp(token, "print") == 0) {
+        } else if (strcmp(token, "print") == 0)      {
             PrintBoard(p);
-        } else if (strcmp(token, "step") == 0) {
+        } else if (strcmp(token, "step") == 0)       {
             ParseMoves(p, ptr);
 #ifdef USE_TUNING
-        } else if (strcmp(token, "tune") == 0) {
+        } else if (strcmp(token, "tune") == 0)       {
             Glob.is_tuning = true;
 #ifndef USE_THREADS
-			printf("FIT: %lf\n", EngineSingle.TexelFit(p, pv));
+            printf("FIT: %lf\n", EngineSingle.TexelFit(p, pv));
 #else
-			printf("FIT: %lf\n", Engines.front().TexelFit(p, Engines.front().pv_eng));
+            printf("FIT: %lf\n", Engines.front().TexelFit(p, Engines.front().pv_eng));
 #endif
             Glob.is_tuning = false;
 #endif
-        } else if (strcmp(token, "bench") == 0) {
+        } else if (strcmp(token, "bench") == 0)      {
             ptr = ParseToken(ptr, token);
 #ifndef USE_THREADS
             EngineSingle.Bench(atoi(token));
 #else
             Engines.front().Bench(atoi(token));
 #endif
-        } else if (strcmp(token, "quit") == 0) {
+        } else if (strcmp(token, "quit") == 0)       {
             exit(0);
         }
     }

--- a/sources/src/uci_options.cpp
+++ b/sources/src/uci_options.cpp
@@ -33,6 +33,9 @@ void PrintUciOptions() {
     printf("option name Clear Hash type button\n");
 
     if (Glob.use_personality_files) {
+            // it's unclear if the default 'rodent.txt' will be loaded by request from the GUI
+            // something should be done with it: 1. read it here or
+            // 2. (better imo) change to 'default ---' to avoid confusion
             printf("option name PersonalityFile type string default rodent.txt\n");
         if (pers_aliases.count != 0) {
             printf("option name Personality type combo default ---"); // `---` in case we want PersonalityFile
@@ -455,8 +458,8 @@ void ReadPersonality(const char *fileName) {
         char *pos = strchr(line, '=');
         if (pos) {
             *pos = '\0';
-            strncpy(pers_aliases.alias[cnt], line, ALIASLEN-1);// -1 coz `strncpy` has a very unexpected glitch
-            strncpy(pers_aliases.path[cnt], pos+1, PATHLEN-1); // see the C11 language standard, note 308
+            strncpy(pers_aliases.alias[cnt], line, PERSALIAS_ALEN-1); // -1 coz `strncpy` has a very unexpected glitch
+            strncpy(pers_aliases.path[cnt], pos+1, PERSALIAS_PLEN-1); // see the C11 language standard, note 308
             while (pos = strpbrk(pers_aliases.path[cnt], "\r\n")) *pos = '\0'; // clean the sh!t
             cnt++;
             continue;
@@ -469,7 +472,7 @@ void ReadPersonality(const char *fileName) {
 
     if (cnt) { // add a fake alias to allow to use PersonalityFile, ReadPersonality will fail on it keeping PersonalityFile values
         strcpy(pers_aliases.alias[cnt], "---");
-        strcpy(pers_aliases.path[cnt], "---");
+        strcpy(pers_aliases.path[cnt], "///");
         cnt++;
     }
     pers_aliases.count = cnt;

--- a/sources/src/uci_options.cpp
+++ b/sources/src/uci_options.cpp
@@ -36,7 +36,8 @@ void PrintUciOptions() {
         // it's unclear if the default 'rodent.txt' will be loaded by request from the GUI
         // something should be done with it: 1. read it here or
         // 2. (better imo) change to 'default ---' to avoid confusion
-        printf("option name PersonalityFile type string default rodent.txt\n");
+        if (pers_aliases.count == 0 || Glob.show_pers_file)
+            printf("option name PersonalityFile type string default rodent.txt\n");
         if (pers_aliases.count != 0) {
             printf("option name Personality type combo default ---"); // `---` in case we want PersonalityFile
             for (int i = 0; i < pers_aliases.count; i++)
@@ -463,6 +464,8 @@ void ReadPersonality(const char *fileName) {
         // which UCI options are exposed to the user?
         if (strstr(line, "HIDE_OPTIONS")) Glob.use_personality_files = true;
         if (strstr(line, "SHOW_OPTIONS")) Glob.use_personality_files = false;
+
+        if (strstr(line, "HIDE_PERSFILE")) Glob.show_pers_file = false;
 
         // aliases for personalities
         char *pos = strchr(line, '=');

--- a/sources/src/uci_options.cpp
+++ b/sources/src/uci_options.cpp
@@ -33,10 +33,10 @@ void PrintUciOptions() {
     printf("option name Clear Hash type button\n");
 
     if (Glob.use_personality_files) {
-            // it's unclear if the default 'rodent.txt' will be loaded by request from the GUI
-            // something should be done with it: 1. read it here or
-            // 2. (better imo) change to 'default ---' to avoid confusion
-            printf("option name PersonalityFile type string default rodent.txt\n");
+        // it's unclear if the default 'rodent.txt' will be loaded by request from the GUI
+        // something should be done with it: 1. read it here or
+        // 2. (better imo) change to 'default ---' to avoid confusion
+        printf("option name PersonalityFile type string default rodent.txt\n");
         if (pers_aliases.count != 0) {
             printf("option name Personality type combo default ---"); // `---` in case we want PersonalityFile
             for (int i = 0; i < pers_aliases.count; i++)
@@ -103,6 +103,15 @@ void PrintUciOptions() {
 
 }
 
+static void valuebool(bool& param, char *val) {
+
+    for (int i = 0; val[i]; i++)
+        val[i] = tolower(val[i]);
+
+    if (strcmp(val, "true")  == 0) param = true;
+    if (strcmp(val, "false") == 0) param = false;
+}
+
 void ParseSetoption(const char *ptr) {
 
     char token[160], name[80], value[160];
@@ -132,267 +141,266 @@ void ParseSetoption(const char *ptr) {
     for (int i = 0; name[i]; i++)   // make `name` lowercase
         name[i] = tolower(name[i]);
 
-    if (strcmp(name, "hash") == 0)                     {
+    if (strcmp(name, "hash") == 0)                                           {
         AllocTrans(atoi(value));
 #ifdef USE_THREADS
-    } else if (strcmp(name, "threads") == 0)           {
+    } else if (strcmp(name, "threads") == 0)                                 {
         Glob.thread_no = (atoi(value));
-        if (Glob.thread_no > MAX_THREADS)
-            Glob.thread_no = MAX_THREADS;
+        if (Glob.thread_no > MAX_THREADS) Glob.thread_no = MAX_THREADS;
 
         Engines.clear();
 
         for (int i = 0; i < Glob.thread_no; i++)
             Engines.emplace_back(i);
 #endif
-    } else if (strcmp(name, "clear hash") == 0)        {
+    } else if (strcmp(name, "clear hash") == 0)                              {
         ClearTrans();
-    } else if (strcmp(name, "pawnvaluemg") == 0)       {
+    } else if (strcmp(name, "pawnvaluemg") == 0)                             {
         Par.values[P_MID] = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "pawnvalueeg") == 0)       {
+    } else if (strcmp(name, "pawnvalueeg") == 0)                             {
         Par.values[P_END] = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "pawnvalue") == 0)         {
+    } else if (strcmp(name, "pawnvalue") == 0)                               {
         SetPieceValue(P, atoi(value), P_MID);
-    } else if (strcmp(name, "knightvaluemg") == 0)     {
+    } else if (strcmp(name, "knightvaluemg") == 0)                           {
         Par.values[N_MID] = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "knightvalueeg") == 0)     {
+    } else if (strcmp(name, "knightvalueeg") == 0)                           {
         Par.values[N_END] = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "knightvalue") == 0)       {
+    } else if (strcmp(name, "knightvalue") == 0)                             {
         SetPieceValue(N, atoi(value), N_MID);
-    } else if (strcmp(name, "bishopvaluemg") == 0)     {
+    } else if (strcmp(name, "bishopvaluemg") == 0)                           {
         Par.values[B_MID] = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "bishopvalueeg") == 0)     {
+    } else if (strcmp(name, "bishopvalueeg") == 0)                           {
         Par.values[B_END] = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "bishopvalue") == 0)       {
+    } else if (strcmp(name, "bishopvalue") == 0)                             {
         SetPieceValue(B, atoi(value), B_MID);
-    } else if (strcmp(name, "rookvaluemg") == 0)       {
+    } else if (strcmp(name, "rookvaluemg") == 0)                             {
         Par.values[R_MID] = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "rookvalueeg") == 0)       {
+    } else if (strcmp(name, "rookvalueeg") == 0)                             {
         Par.values[R_END] = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "rookvalue") == 0)         {
+    } else if (strcmp(name, "rookvalue") == 0)                               {
         SetPieceValue(R, atoi(value), R_MID);
-    } else if (strcmp(name, "queenvaluemg") == 0)      {
+    } else if (strcmp(name, "queenvaluemg") == 0)                            {
         Par.values[Q_MID] = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "queenvalueeg") == 0)      {
+    } else if (strcmp(name, "queenvalueeg") == 0)                            {
         Par.values[Q_END] = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "queenvalue") == 0)        {
+    } else if (strcmp(name, "queenvalue") == 0)                              {
         SetPieceValue(Q, atoi(value), Q_MID);
-    } else if (strcmp(name, "keeppawn") == 0)          {
+    } else if (strcmp(name, "keeppawn") == 0)                                {
         Par.keep_pc[P] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "keepknight") == 0)        {
+    } else if (strcmp(name, "keepknight") == 0)                              {
         Par.keep_pc[N] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "keepbishop") == 0)        {
+    } else if (strcmp(name, "keepbishop") == 0)                              {
         Par.keep_pc[B] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "keeprook") == 0)          {
+    } else if (strcmp(name, "keeprook") == 0)                                {
         Par.keep_pc[R] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "keepqueen") == 0)         {
+    } else if (strcmp(name, "keepqueen") == 0)                               {
         Par.keep_pc[Q] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "na1") == 0 )              {
+    } else if (strcmp(name, "na1") == 0 )                                    {
         Par.values[N_ATT1] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "na2") == 0 )              {
+    } else if (strcmp(name, "na2") == 0 )                                    {
         Par.values[N_ATT2] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "ba1") == 0 )              {
+    } else if (strcmp(name, "ba1") == 0 )                                    {
         Par.values[B_ATT1] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "ba2") == 0 )              {
+    } else if (strcmp(name, "ba2") == 0 )                                    {
         Par.values[B_ATT2] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "ra1") == 0 )              {
+    } else if (strcmp(name, "ra1") == 0 )                                    {
         Par.values[R_ATT1] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "ra2") == 0 )              {
+    } else if (strcmp(name, "ra2") == 0 )                                    {
         Par.values[R_ATT2] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "qa1") == 0 )              {
+    } else if (strcmp(name, "qa1") == 0 )                                    {
         Par.values[Q_ATT1] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "qa2") == 0 )              {
+    } else if (strcmp(name, "qa2") == 0 )                                    {
         Par.values[Q_ATT2] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "nch") == 0 )              {
+    } else if (strcmp(name, "nch") == 0 )                                    {
         Par.values[N_CHK] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "bch") == 0 )              {
+    } else if (strcmp(name, "bch") == 0 )                                    {
         Par.values[B_CHK] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "rch") == 0 )              {
+    } else if (strcmp(name, "rch") == 0 )                                    {
         Par.values[R_CHK] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "qch") == 0 )              {
+    } else if (strcmp(name, "qch") == 0 )                                    {
         Par.values[Q_CHK] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "qcon") == 0 )             {
+    } else if (strcmp(name, "qcon") == 0 )                                   {
         Par.values[Q_CONTACT] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "rcon") == 0 )             {
+    } else if (strcmp(name, "rcon") == 0 )                                   {
         Par.values[R_CONTACT] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "bishoppair") == 0)        {
+    } else if (strcmp(name, "bishoppair") == 0)                              {
         Par.values[B_PAIR] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "exchangeimbalance") == 0) {
+    } else if (strcmp(name, "exchangeimbalance") == 0)                       {
         Par.values[A_EXC] = atoi(value);
         Par.InitMaterialTweaks();
         Glob.should_clear = true;
-    } else if (strcmp(name, "knightlikesclosed") == 0) {
+    } else if (strcmp(name, "knightlikesclosed") == 0)                       {
         Par.values[N_CL] = atoi(value);
         Par.InitMaterialTweaks();
         Glob.should_clear = true;
-    } else if (strcmp(name, "rooklikesopen") == 0)     {
+    } else if (strcmp(name, "rooklikesopen") == 0)                           {
         Par.values[R_OP] = atoi(value);
         Par.InitMaterialTweaks();
         Glob.should_clear = true;
-    } else if (strcmp(name, "material") == 0)          {
+    } else if (strcmp(name, "material") == 0)                                {
         Par.mat_weight = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "pieceplacement") == 0)    {
+    } else if (strcmp(name, "pieceplacement") == 0)                          {
         Par.pst_weight = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "ownattack") == 0)         {
+    } else if (strcmp(name, "ownattack") == 0)                               {
         Par.own_att_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "oppattack") == 0)         {
+    } else if (strcmp(name, "oppattack") == 0)                               {
         Par.opp_att_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "ownmobility") == 0)       {
+    } else if (strcmp(name, "ownmobility") == 0)                             {
         Par.own_mob_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "oppmobility") == 0)       {
+    } else if (strcmp(name, "oppmobility") == 0)                             {
         Par.opp_mob_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "kingtropism") == 0)       {
+    } else if (strcmp(name, "kingtropism") == 0)                             {
         Par.tropism_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "forwardness") == 0)       {
+    } else if (strcmp(name, "forwardness") == 0)                             {
         Par.forward_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "piecepressure") == 0)     {
+    } else if (strcmp(name, "piecepressure") == 0)                           {
         Par.threats_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "passedpawns") == 0)       {
+    } else if (strcmp(name, "passedpawns") == 0)                             {
         Par.passers_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "pawnstructure") == 0)     {
+    } else if (strcmp(name, "pawnstructure") == 0)                           {
         Par.struct_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "pawnmass") == 0)          {
+    } else if (strcmp(name, "pawnmass") == 0)                                {
         Par.pawn_mass_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "pawnshield") == 0)        {
+    } else if (strcmp(name, "pawnshield") == 0)                              {
         Par.shield_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "pawnstorm") == 0)         {
+    } else if (strcmp(name, "pawnstorm") == 0)                               {
         Par.storm_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "outposts") == 0)          {
+    } else if (strcmp(name, "outposts") == 0)                                {
         Par.outposts_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "lines") == 0)             {
+    } else if (strcmp(name, "lines") == 0)                                   {
         Par.lines_weight = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "fianchetto") == 0)        {
+    } else if (strcmp(name, "fianchetto") == 0)                              {
         Par.values[B_KING] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "doubledpawnmg") == 0)     {
+    } else if (strcmp(name, "doubledpawnmg") == 0)                           {
         Par.values[DB_MID] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "doubledpawneg") == 0)     {
+    } else if (strcmp(name, "doubledpawneg") == 0)                           {
         Par.values[DB_END] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "isolatedpawnmg") == 0)    {
+    } else if (strcmp(name, "isolatedpawnmg") == 0)                          {
         Par.values[ISO_MG] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "isolatedpawneg") == 0)    {
+    } else if (strcmp(name, "isolatedpawneg") == 0)                          {
         Par.values[ISO_EG] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "isolatedopenmg") == 0)    {
+    } else if (strcmp(name, "isolatedopenmg") == 0)                          {
         Par.values[ISO_OF] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "backwardpawneg") == 0)    {
+    } else if (strcmp(name, "backwardpawneg") == 0)                          {
         Par.values[BK_MID] = atoi(value);
         Par.InitBackward();
         Glob.should_clear = true;
-    } else if (strcmp(name, "backwardpawneg") == 0)    {
+    } else if (strcmp(name, "backwardpawneg") == 0)                          {
         Par.values[BK_END] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "backwardopenmg") == 0)    {
+    } else if (strcmp(name, "backwardopenmg") == 0)                          {
         Par.values[BK_OPE] = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "pststyle") == 0)          {
+    } else if (strcmp(name, "pststyle") == 0)                                {
         Par.pst_style = atoi(value);
         Par.InitPst();
         Glob.should_clear = true;
-    } else if (strcmp(name, "mobilitystyle") == 0)     {
+    } else if (strcmp(name, "mobilitystyle") == 0)                           {
         Par.mob_style = atoi(value);
         Par.InitMobility();
         Glob.should_clear = true;
-    } else if (strcmp(name, "guidebookfile") == 0)     {
-        if (!Glob.separate_books
-        || !Glob.reading_personality) {
+    } else if (strcmp(name, "guidebookfile") == 0)                           {
+        if (!Glob.separate_books || !Glob.reading_personality)
             GuideBook.SetBookName(value);
-        }
-    } else if (strcmp(name, "mainbookfile") == 0)      {
-        if (!Glob.separate_books
-        || !Glob.reading_personality) {
+    } else if (strcmp(name, "mainbookfile") == 0)                            {
+        if (!Glob.separate_books || !Glob.reading_personality)
             MainBook.SetBookName(value);
-        }
-    } else if (strcmp(name, "contempt") == 0)          {
+    } else if (strcmp(name, "contempt") == 0)                                {
         Par.draw_score = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "evalblur") == 0)          {
+    } else if (strcmp(name, "evalblur") == 0)                                {
         Par.eval_blur = atoi(value);
         Glob.should_clear = true;
-    } else if (strcmp(name, "npslimit") == 0)          {
+    } else if (strcmp(name, "npslimit") == 0)                                {
         Par.nps_limit = atoi(value);
-    } else if (strcmp(name, "uci_elo") == 0) {
+    } else if (strcmp(name, "uci_elo") == 0)                                 {
         Par.elo = atoi(value);
         Par.SetSpeed(Par.elo);
-    } else if (strcmp(name, "searchskill") == 0)       {
+    } else if (strcmp(name, "uci_limitstrength") == 0)                       {
+        valuebool(Par.fl_weakening, value);
+    } else if (strcmp(name, "usebook") == 0)                                 {
+        valuebool(Par.use_book, value);
+    } else if (strcmp(name, "searchskill") == 0)                             {
         Par.search_skill = atoi(value);
         Glob.should_clear = true;
 #ifdef USE_RISKY_PARAMETER
-    } else if (strcmp(name, "riskydepth") == 0)        {
+    } else if (strcmp(name, "riskydepth") == 0)                              {
         Par.riskydepth = atoi(value);
         Glob.should_clear = true;
 #endif
-    } else if (strcmp(name, "slowmover") == 0)         {
+    } else if (strcmp(name, "slowmover") == 0)                               {
         Par.time_percentage = atoi(value);
-    } else if (strcmp(name, "selectivity") == 0)       {
+    } else if (strcmp(name, "selectivity") == 0)                             {
         Par.hist_perc = atoi(value);
         Par.hist_limit = -MAX_HIST + ((MAX_HIST * Par.hist_perc) / 100);
         Glob.should_clear = true;
-    } else if (strcmp(name, "personalityfile") == 0)   {
+    } else if (strcmp(name, "personalityfile") == 0)                         {
         ReadPersonality(value);
-    } else if (strcmp(name, "personality") == 0 )      {
+    } else if (strcmp(name, "personality") == 0 )                            {
         for (int i = 0; i < pers_aliases.count; i++)
             if (strcmp(pers_aliases.alias[i], value) == 0) {
                 ReadPersonality(pers_aliases.path[i]);

--- a/sources/src/uci_options.cpp
+++ b/sources/src/uci_options.cpp
@@ -125,6 +125,7 @@ void ParseSetoption(const char *ptr) {
         strcat(name, token);
         strcat(name, " ");
     }
+    if (name[0] == '\0') return;
     name[strlen(name) - 1] = '\0';
     if (strcmp(token, "value") == 0) {
         value[0] = '\0';
@@ -135,11 +136,12 @@ void ParseSetoption(const char *ptr) {
             strcat(value, token);
             strcat(value, " ");
         }
+        if (value[0] == '\0') return;
         value[strlen(value) - 1] = '\0';
     }
 
     for (int i = 0; name[i]; i++)   // make `name` lowercase
-        name[i] = tolower(name[i]);
+        name[i] = tolower(name[i]); // we can't lowercase `value` 'coz paths are case-sensitive on linux
 
     if (strcmp(name, "hash") == 0)                                           {
         AllocTrans(atoi(value));


### PR DESCRIPTION
1. support for personalities aliases. you can do something like this in **basic.ini** (don't add unnecessary spaces around equal sign)

```
HIDE_OPTIONS
PERSONALITY_BOOKS
NPS_BLUR

amy=personalities/school/amy.txt
anand=personalities/famous/anand.txt
anderssen=personalities/famous/anderssen.txt
andy=personalities/school/andy.txt
arthur=personalities/league/arthur.txt
ben=personalities/school/ben.txt
botvinnik=personalities/famous/botvinnik.txt
chris=personalities/school/chris.txt
```

It will add `option name Personality type combo default --- var amy var anand var anderssen var andy var arthur var ben var botvinnik var chris var ---` to the parameters list. Of course there is a problem **Personality** vs **PersonalityFile** since it depends on what the GUI sends to the engine last. Therefore an user should set unused parameter (**Personality** or **PersonalityFile**) to some fake value, like `---` or `///`.
Or maybe Rodent should just hide **PersonalityFile** from the options if **Personality** is used (aliases are found). I'm not sure here.
Implementation is very simple using a static array.

2. added `.editorconfig` (see http://editorconfig.org/) at least now on github _tab_ == _4_ spaces, not _8_ as it was. no more line jumping.

3. options **UCI_LimitStrength** and **UseBook** moved to _uci_options.cpp_