### PR TITLE
Proper parsing for setoption

### DIFF
--- a/sources/src/book.cpp
+++ b/sources/src/book.cpp
@@ -368,7 +368,6 @@ int sBook::GetPolyglotMove(POS *p, bool print_output) {
     n_of_choices = 0;
 
     if (bookFile != NULL) {
-        srand(GetMS());
 
         for (pos = FindPos(key); pos < book_size; pos++) {
 
@@ -478,12 +477,6 @@ void sBook::ClosePolyglot() {
         bookFile = NULL;
     }
 }
-
-//void sBook::Init() {
-//
-//  bookFile = NULL;
-//  book_size = 0;
-//}
 
 bool sBook::IsInfrequent(int val, int max_freq) {
 

--- a/sources/src/book.h
+++ b/sources/src/book.h
@@ -18,6 +18,7 @@ If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include <cstdio>
+#include <cstring>
 
 struct polyglot_move {
     U64 key;
@@ -44,13 +45,9 @@ struct sBook {
   public:
     sBook(): bookFile(NULL) {}
     void SetBookName(const char *name) {
-        int i;
-        for (i = 0; (name[i] >= 0x20) && (i < sizeof(bookName) - 1); i++)
-            bookName[i] = name[i];
-        bookName[i] = '\0';
 
+        strcpy(bookName, name);
         OpenPolyglot();
-
         printf("info string opening book file \'%s\' (%s)\n", bookName, bookFile == NULL ? "failure" : "success");
     }
     ~sBook() { ClosePolyglot(); }

--- a/sources/src/book_internal.cpp
+++ b/sources/src/book_internal.cpp
@@ -6212,8 +6212,6 @@ int sInternalBook::MoveFromInternal(POS *p) {
 
     if (n_of_choices) {
 
-        srand(GetMS());
-
         for (i = 0; i < n_of_choices; i++) {
 
             // pick move with the best random value based on frequency

--- a/sources/src/chessheapclass.h
+++ b/sources/src/chessheapclass.h
@@ -42,7 +42,7 @@ class ChessHeapClass {
 
 #ifndef NDEBUG
             if (success)
-                printf("allocated: %dMB\n", bucket_sizs[i]);
+                printf("(debug) allocated: %dMB\n", bucket_sizs[i]);
 #endif
         }
 

--- a/sources/src/main.cpp
+++ b/sources/src/main.cpp
@@ -17,6 +17,7 @@ If not, see <http://www.gnu.org/licenses/>.
 
 #include "rodent.h"
 #include "book.h"
+#include <cstdlib>
 
 cGlobals Glob;
 
@@ -52,7 +53,9 @@ int main() {
 		printf("%3d : %d\n", i, (int)j);
 	}
 	*/
-	
+
+    srand(GetMS());
+
     BB.Init();
     InitSearch();
     Init();

--- a/sources/src/popcnt_ssse3.h
+++ b/sources/src/popcnt_ssse3.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <tmmintrin.h>
 
 static const __m128i popcount_mask = _mm_set1_epi8(0x0F);

--- a/sources/src/uci_options.cpp
+++ b/sources/src/uci_options.cpp
@@ -143,6 +143,10 @@ void ParseSetoption(const char *ptr) {
     for (int i = 0; name[i]; i++)   // make `name` lowercase
         name[i] = tolower(name[i]); // we can't lowercase `value` 'coz paths are case-sensitive on linux
 
+#ifndef NDEBUG
+    printf( "(debug) setoption name:  '%s' value: '%s'\n", name, value );
+#endif
+
     if (strcmp(name, "hash") == 0)                                           {
         AllocTrans(atoi(value));
 #ifdef USE_THREADS

--- a/sources/src/uci_options.cpp
+++ b/sources/src/uci_options.cpp
@@ -144,7 +144,7 @@ void ParseSetoption(const char *ptr) {
         name[i] = tolower(name[i]); // we can't lowercase `value` 'coz paths are case-sensitive on linux
 
 #ifndef NDEBUG
-    printf( "(debug) setoption name:  '%s' value: '%s'\n", name, value );
+    printf( "(debug) setoption name: '%s' value: '%s'\n", name, value );
 #endif
 
     if (strcmp(name, "hash") == 0)                                           {
@@ -452,9 +452,11 @@ void ReadPersonality(const char *fileName) {
     // set flag in case we want to disable some options while reading personality from a file
     Glob.reading_personality = true;
 
-    char line[256], token[180]; int cnt = 0;
+    char line[256], token[180]; int cnt = 0; char *pos;
 
     while (fgets(line, sizeof(line), personalityFile)) {    // read options line by line
+
+        while (pos = strpbrk(line, "\r\n")) *pos = '\0'; // clean the sh!t
 
         // do we pick opening book within a personality?
         if (strstr(line, "PERSONALITY_BOOKS")) Glob.separate_books = false;
@@ -471,12 +473,11 @@ void ReadPersonality(const char *fileName) {
         if (strstr(line, "HIDE_PERSFILE")) Glob.show_pers_file = false;
 
         // aliases for personalities
-        char *pos = strchr(line, '=');
+        pos = strchr(line, '=');
         if (pos) {
             *pos = '\0';
             strncpy(pers_aliases.alias[cnt], line, PERSALIAS_ALEN-1); // -1 coz `strncpy` has a very unexpected glitch
             strncpy(pers_aliases.path[cnt], pos+1, PERSALIAS_PLEN-1); // see the C11 language standard, note 308
-            while (pos = strpbrk(pers_aliases.path[cnt], "\r\n")) *pos = '\0'; // clean the sh!t
             cnt++;
             continue;
         }

--- a/sources/src/uci_options.cpp
+++ b/sources/src/uci_options.cpp
@@ -113,40 +113,32 @@ static void valuebool(bool& param, char *val) {
     if (strcmp(val, "false") == 0) param = false;
 }
 
-static void trimstring(char *in_str) {
+static char *pseudotrimstring(char *in_str) {
 
-    int first_non_space;
-    for (first_non_space = 0; in_str[first_non_space] == ' '; first_non_space++);
+    for (int last = strlen(in_str)-1; last >= 0 && in_str[last] == ' '; last--)
+        in_str[last] = '\0';
 
-    int last_non_space;
-    for (last_non_space = strlen(in_str)-1; last_non_space >= 0 && in_str[last_non_space] == ' '; last_non_space--)
-        in_str[last_non_space] = '\0';
+    while (*in_str == ' ') in_str++;
 
-    if (last_non_space > 0)
-        memmove(in_str, in_str + first_non_space, last_non_space - first_non_space + 2);
+    return in_str;
 }
 
 void ParseSetoption(const char *ptr) {
 
-    char name[80], value[200];
+    char *name, *value;
 
-    const char *npos = strstr(ptr, " name ");    // len(" name ") == 6, len(" value ") == 7
+    char *npos = (char *)strstr(ptr, " name ");  // len(" name ") == 6, len(" value ") == 7
     char *vpos = (char *)strstr(ptr, " value "); // sorry for an ugly "unconst"
 
-    if ( !npos || (vpos && npos + 6 > vpos) ) return; // if no 'name' or name field is empty
+    if ( !npos ) return; // if no 'name'
 
     if ( vpos ) {
         *vpos = '\0';
-        strcpy(value, vpos + 7);
-        trimstring(value);
+        value = pseudotrimstring(vpos + 7);
     }
-    else
-        value[0] = '\0'; // btw, empty value field is against the rules so the word 'value' goes to the name buf in that case
+    else value = npos; // fake, just to prevent possible crash if misusing
 
-    strcpy(name, npos + 6);
-    trimstring(name);
-
-    if (!name[0]) return;
+    name = pseudotrimstring(npos + 6);
 
     for (int i = 0; name[i]; i++)   // make `name` lowercase
         name[i] = tolower(name[i]); // we can't lowercase `value` 'coz paths are case-sensitive on linux


### PR DESCRIPTION
properly parse name and value for `setoption`, previous approach destroys repeated spaces.