### PR TITLE
compile on Linux

### DIFF
--- a/sources/Makefile
+++ b/sources/Makefile
@@ -1,21 +1,22 @@
-#makefile to compile Rodent II on Linux
+#makefile to compile Rodent III on Linux
+PREFIX=/usr/local
 
 #define the directory for the executable file
-BINDIR = /usr/bin
+BINDIR = $(PREFIX)/bin
 
 #define the directory for the data files
-DATADIR = /usr/share/rodentIII
+DATADIR = $(PREFIX)/share/rodentIII
 
 
 # define the C compiler to use
 CC = g++
 
 # define the compile-time flags
-CFLAGS = -g -w -Wfatal-errors -pipe -DNDEBUG -O3 -fno-rtti -finline-functions -fprefetch-loop-arrays -DBOOKPATH=$(DATADIR)
-C1FLAGS = -g -w -Wfatal-errors -pipe -DWRITEDEBUGFILE -DBOOKPATH=$(DATADIR)
+CFLAGS = -g -std=c++14 -pthread -w -Wfatal-errors -pipe -DNDEBUG -O3 -fno-rtti -finline-functions -fprefetch-loop-arrays -DBOOKPATH=$(DATADIR)
+C1FLAGS = -g -std=c++14 -pthread -w -Wfatal-errors -pipe -DWRITEDEBUGFILE -DBOOKPATH=$(DATADIR)
 
 # define the link options
-LDFLAGS = -s -lm
+LDFLAGS = -s -lm -Wl,--no-as-needed
 LD1FLAGS = -lm
 
 # define outpout name and settings file

--- a/sources/compile.linux
+++ b/sources/compile.linux
@@ -1,5 +1,6 @@
 #include "src/attacks.cpp"
 #include "src/bitboard.cpp"
+#include "src/book_internal.cpp"
 #include "src/book.cpp"
 #include "src/data.cpp"
 #include "src/eval.cpp"


### PR DESCRIPTION
This is a proposal to update the `Makefile` and `compile.linux`.
It may work with recent g++-versions.

-----
I compiled Rodent III even with my old compiler after backporting to C++11 some recent incompatibilies.

```
id name Rodent III 0.207 64-bit/GCC 4.8.4
info string opening book file '/usr/local/share/rodentIII/rodent.bin' (success)
info string opening book file '/usr/local/share/rodentIII/guide.bin' (success)
info string reading '/usr/local/share/rodentIII/basic.ini' (success)
info string 40380 moves loaded from the internal book
info string 16MB of memory allocated
```
