### PR TITLE
added simple bat-file to build x32/x64/POPCNT/noPOPCNT builds for Visual Studio

### DIFF
--- a/sources/buildme_vs2017.bat
+++ b/sources/buildme_vs2017.bat
@@ -1,0 +1,34 @@
+@echo off
+
+setlocal
+
+set vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+
+for /f "usebackq tokens=*" %%i in (`%vswhere% -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
+  set InstallDir=%%i
+)
+
+call "%InstallDir%\Common7\Tools\VsDevCmd.bat" -arch=x86
+
+set POPCNTDEF=
+set ENAME="rodent_vs2017_x32_POPCNT.exe"
+call :build
+
+set POPCNTDEF=/D NO_MM_POPCNT
+set ENAME="rodent_vs2017_x32_noPOPCNT.exe"
+call :build
+
+call "%InstallDir%\Common7\Tools\VsDevCmd.bat" -arch=amd64
+
+set POPCNTDEF=
+set ENAME="rodent_vs2017_x64_POPCNT.exe"
+call :build
+
+set POPCNTDEF=/D NO_MM_POPCNT
+set ENAME="rodent_vs2017_x64_noPOPCNT.exe"
+
+:build
+
+cl /O2 /GL /Gw /GS- /wd4577 /wd4530 /analyze- /MP /MT /Zc:inline /fp:fast /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_CRT_SECURE_NO_WARNINGS" /D "USE_THREADS" /D "NEW_THREADS" /D "USEGEN" %POPCNTDEF% src/*.cpp /link /SAFESEH:NO /LTCG /OPT:REF /OPT:ICF /SUBSYSTEM:CONSOLE /LARGEADDRESSAWARE /OUT:%ENAME%
+
+del /q *.obj

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -34,7 +34,9 @@ using U64 = uint64_t;
 // define how Rodent is to be compiled
 
 #define USE_MAGIC
-#define USE_MM_POPCNT
+#ifndef NO_MM_POPCNT
+    #define USE_MM_POPCNT
+#endif
 #define USE_FIRST_ONE_INTRINSICS
 //#define USE_TUNING // needs epd.cpp, long compile time, huge file!!!
 


### PR DESCRIPTION
tested on Win7 + MS Visual Studio 2017 15.2 (26430.15)

feel free to change the compiler flags to anything you like.