### PR TITLE
add -DUSEGEN to compiler flags in Makefile

### DIFF
--- a/sources/Makefile
+++ b/sources/Makefile
@@ -12,8 +12,8 @@ DATADIR = $(PREFIX)/share/rodentIII
 CC = g++
 
 # define the compile-time flags
-CFLAGS = -g -std=c++14 -pthread -w -Wfatal-errors -pipe -DNDEBUG -O3 -fno-rtti -finline-functions -fprefetch-loop-arrays -DBOOKPATH=$(DATADIR)
-C1FLAGS = -g -std=c++14 -pthread -w -Wfatal-errors -pipe -DWRITEDEBUGFILE -DBOOKPATH=$(DATADIR)
+CFLAGS = -g -std=c++14 -pthread -w -Wfatal-errors -pipe -DNDEBUG -DUSEGEN -O3 -fno-rtti -finline-functions -fprefetch-loop-arrays -DBOOKPATH=$(DATADIR)
+C1FLAGS = -g -std=c++14 -pthread -w -Wfatal-errors -pipe -DWRITEDEBUGFILE -DUSEGEN -DBOOKPATH=$(DATADIR)
 
 # define the link options
 LDFLAGS = -s -lm -Wl,--no-as-needed


### PR DESCRIPTION
In #28 I forgot to set flag -DUSEGEN. Compiled with this flag the engine starts much faster. Thanks @tico-tico for the hint.