### PR TITLE
Revert "1-arg overload for MoveToStr() returns internal char[6]"

### DIFF
--- a/docs/changes-tmp.txt
+++ b/docs/changes-tmp.txt
@@ -29,3 +29,5 @@ just to not forget user/builder visible changes
 9. new uci parameter VerboseBook controls if RodentIII prints move choices from an opening book
 
 10. On linux BOOKSPATH and/or PERSONALITIESPATH can be overridden by defining RIIIBOOKS and/or RIIIPERSONALITIES environment variables. if paths, pointed by RIIIBOOKS and/or RIIIPERSONALITIES don't exist then RodentIII uses built-in BOOKSPATH and/or PERSONALITIESPATH as fallbacks.
+
+11. new uci command `stepp` = `step` + `print`

--- a/sources/src/book.cpp
+++ b/sources/src/book.cpp
@@ -334,8 +334,8 @@ void sBook::OpenPolyglot() {
 
     ClosePolyglot();
 
-    if (!ChDirEnv("RIIIBOOKS"))
-        if (!ChDir(_BOOKSPATH)) return;
+    if (!ChDirEnv("RIIIBOOKS"))             // try `RIIIBOOKS` env var first (26/08/17: linux only)
+        if (!ChDir(_BOOKSPATH)) return;     // then buit-in path
     bookFile = fopen(bookName, "rb");
 
     if (bookFile == NULL) return;
@@ -471,10 +471,10 @@ U64 sBook::ReadInteger(int size) {
 
     U64 n = 0;
 
-    if (bookMemory)
+    if (bookMemory)     // book from memory
         for (int i = 0; i < size; i++)
             n = (n << 8) | bookMemory[bookMemoryPos++];
-    else
+    else                // book from file
         for (int i = 0; i < size; i++)
             n = (n << 8) | (unsigned char)fgetc(bookFile);
 

--- a/sources/src/book.cpp
+++ b/sources/src/book.cpp
@@ -377,6 +377,7 @@ int sBook::GetPolyglotMove(POS *p, bool print_output) {
     int values[100], moves[100];
     polyglot_move entry[1];
     U64 key = GetPolyglotKey(p);
+    char move_string[6];
 
     printf("info string probing '%s'...\n", bookName);
 
@@ -400,7 +401,8 @@ int sBook::GetPolyglotMove(POS *p, bool print_output) {
         // now we want to get a move with full data, not only from and to squares
 
         int internal_move = (tsq << 6) | fsq;
-        internal_move = StrToMove(p, MoveToStr(internal_move));
+        MoveToStr(internal_move, move_string);
+        internal_move = StrToMove(p, move_string);
 
         if (max_weight < score) max_weight = score;
         weight_sum += score;

--- a/sources/src/book_internal.cpp
+++ b/sources/src/book_internal.cpp
@@ -141,7 +141,7 @@ int sInternalBook::MoveFromInternal(POS *p, bool print_output) const {
 
     printf("info string probing the internal book...\n");
 
-    int choice = 0;
+    int choice = 0; char mv_string[6];
 
     const int min_freq = 20; // the higher this value, the more uniform move distribution
 
@@ -163,7 +163,8 @@ int sInternalBook::MoveFromInternal(POS *p, bool print_output) const {
 
             // display info about book moves
             if (print_output) {
-                printf("info string %s %d\n", MoveToStr(internal_book[i].move), freq_with_correction);
+                MoveToStr(internal_book[i].move, mv_string);
+                printf("info string %s %d\n", mv_string, freq_with_correction);
             }
 
             // pick move with the best random value based on frequency

--- a/sources/src/main.cpp
+++ b/sources/src/main.cpp
@@ -100,7 +100,7 @@ int main() {
     printf("info string personalities path is '%s'\n", _PERSONALITIESPATH);
 #endif
 
-    PrintOverrides();
+    PrintOverrides(); // print books and pers paths overrides (26/08/17: linux only)
 
 #ifndef BOOKGEN
     GuideBook.SetBookName("guide.bin");

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -523,14 +523,14 @@ class cParam {
     NOINLINE void InitBackward();
     NOINLINE void InitPassers();
     NOINLINE void InitMaterialTweaks();
-    void InitTables();
-    void DefaultWeights();
-    void InitAsymmetric(POS *p);
-    void SetSpeed(int elo_in);
-    int EloToSpeed(int elo_in);
-    int EloToBlur(int elo_in);
-    int EloToBookDepth(int elo_in);
-    void SetVal(int slot, int val);
+    NOINLINE void InitTables();
+    NOINLINE void DefaultWeights();
+    NOINLINE void InitAsymmetric(POS *p);
+    NOINLINE void SetSpeed(int elo_in);
+    NOINLINE int EloToSpeed(int elo_in);
+    NOINLINE int EloToBlur(int elo_in);
+    NOINLINE int EloToBookDepth(int elo_in);
+    NOINLINE void SetVal(int slot, int val);
 };
 
 extern cParam Par;

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -799,7 +799,6 @@ int GetMS();
 U64 GetNps(int elapsed);
 bool InputAvailable();
 bool Legal(POS *p, int move);
-char *MoveToStr(int move);
 void MoveToStr(int move, char *move_str);
 void ParseGo(POS *p, const char *ptr);
 void ParseMoves(POS *p, const char *ptr);

--- a/sources/src/uci.cpp
+++ b/sources/src/uci.cpp
@@ -220,7 +220,7 @@ void SetMoveTime(int base, int inc, int movestogo) {
 
 void ParseGo(POS *p, const char *ptr) {
 
-    char token[80];
+    char token[80], bestmove_str[6];
     int wtime, btime, winc, binc, movestogo; bool strict_time;
     int pvb;
 
@@ -303,7 +303,8 @@ void ParseGo(POS *p, const char *ptr) {
         if (!pvb) pvb = InternalBook.MoveFromInternal(p, Par.verbose_book);
 
         if (pvb) {
-            printf("bestmove %s\n", MoveToStr(pvb));
+            MoveToStr(pvb, bestmove_str);
+            printf("bestmove %s\n", bestmove_str);
             return;
         }
     }

--- a/sources/src/uci.cpp
+++ b/sources/src/uci.cpp
@@ -93,6 +93,9 @@ void UciLoop() {
             PrintBoard(p);
         } else if (strcmp(token, "step") == 0)       {
             ParseMoves(p, ptr);
+        } else if (strcmp(token, "stepp") == 0)      {
+            ParseMoves(p, ptr);
+            PrintBoard(p);
 #ifdef USE_TUNING
         } else if (strcmp(token, "tune") == 0)       {
             Glob.is_tuning = true;
@@ -222,7 +225,6 @@ void ParseGo(POS *p, const char *ptr) {
 
     char token[80], bestmove_str[6];
     int wtime, btime, winc, binc, movestogo; bool strict_time;
-    int pvb;
 
     move_time = -1;
     move_nodes = 0;
@@ -298,7 +300,7 @@ void ParseGo(POS *p, const char *ptr) {
 
         printf("info string bd %d mfs %d\n", Par.book_depth, Glob.moves_from_start);
 
-        pvb = GuideBook.GetPolyglotMove(p, Par.verbose_book);
+        int pvb = GuideBook.GetPolyglotMove(p, Par.verbose_book);
         if (!pvb) pvb = MainBook.GetPolyglotMove(p, Par.verbose_book);
         if (!pvb) pvb = InternalBook.MoveFromInternal(p, Par.verbose_book);
 

--- a/sources/src/uci_options.cpp
+++ b/sources/src/uci_options.cpp
@@ -575,7 +575,8 @@ void SetPieceValue(int pc, int val, int slot) {
 void ReadPersonality(const char *fileName) {
 
     FILE *personalityFile = NULL;
-    if (ChDirEnv("RIIIPERSONALITIES") || ChDir(_PERSONALITIESPATH))
+    if (ChDirEnv("RIIIPERSONALITIES")       // try `RIIIPERSONALITIES` env var first (26/08/17: linux only)
+        || ChDir(_PERSONALITIESPATH))       // then buit-in path
             personalityFile = fopen(fileName, "r");
 
     printf("info string reading personality '%s' (%s)\n", fileName, personalityFile == NULL ? "failure" : "success");

--- a/sources/src/util.cpp
+++ b/sources/src/util.cpp
@@ -124,14 +124,9 @@ void POS::InitPawnKey() {
 
 void PrintMove(int move) {
 
-    printf("%s", MoveToStr(move));
-}
-
-char *MoveToStr(int move) {
-
-    static char internalstring[6];
-    MoveToStr(move, internalstring);
-    return internalstring;
+    char moveString[6];
+    MoveToStr(move, moveString);
+    printf("%s", moveString);
 }
 
 void MoveToStr(int move, char *move_str) {
@@ -200,10 +195,12 @@ int StrToMove(POS *p, char *move_str) {
 void PvToStr(int *pv, char *pv_str) {
 
     int *movep;
+    char move_str[6];
 
     pv_str[0] = '\0';
     for (movep = pv; *movep; movep++) {
-        strcat(pv_str, MoveToStr(*movep));
+        MoveToStr(*movep, move_str);
+        strcat(pv_str, move_str);
         strcat(pv_str, " ");
     }
 }


### PR DESCRIPTION
reverted to quickfix moves output in multi-thread mode