### PR TITLE
Dev 2017 09 08

### DIFF
--- a/sources/src/eval.cpp
+++ b/sources/src/eval.cpp
@@ -23,8 +23,8 @@ If not, see <http://www.gnu.org/licenses/>.
 
 static const U64 bb_center = SqBb(C3) | SqBb(D3) | SqBb(E3) | SqBb(F3)
                            | SqBb(C4) | SqBb(D4) | SqBb(E4) | SqBb(F4)
-	                       | SqBb(C5) | SqBb(D5) | SqBb(E5) | SqBb(F5)
-	                       | SqBb(C6) | SqBb(D6) | SqBb(E6) | SqBb(F6);
+                           | SqBb(C5) | SqBb(D5) | SqBb(E5) | SqBb(F5)
+                           | SqBb(C6) | SqBb(D6) | SqBb(E6) | SqBb(F6);
 
 void cEngine::ClearAll() {
 
@@ -73,7 +73,7 @@ void cEngine::EvaluatePieces(POS *p, eData *e, int sd) {
     int outpost = 0;
     int att = 0;
     int wood = 0;
-	int center_control = 2 * BB.PopCnt(e->p_takes[sd] & bb_center);
+    int center_control = 2 * BB.PopCnt(e->p_takes[sd] & bb_center);
 
     // Init king attack zone
 
@@ -107,7 +107,7 @@ void cEngine::EvaluatePieces(POS *p, eData *e, int sd) {
         }
 
         bb_control = BB.KnightAttacks(sq) & ~p->cl_bb[sd];  // get control bitboard
-		center_control += BB.PopCnt(bb_control & bb_center);
+        center_control += BB.PopCnt(bb_control & bb_center);
         if (!(bb_control  & ~e->p_takes[op] & Mask.away[sd])) // we do not attack enemy half of the board
             Add(e, sd, Par.values[N_OWH]);
         e->all_att[sd] |= BB.KnightAttacks(sq);
@@ -150,7 +150,7 @@ void cEngine::EvaluatePieces(POS *p, eData *e, int sd) {
         }
 
         bb_control = BB.BishAttacks(OccBb(p), sq);          // get control bitboard
-		center_control += BB.PopCnt(bb_control & bb_center);
+        center_control += BB.PopCnt(bb_control & bb_center);
         e->all_att[sd] |= bb_control;                       // update attack map
         e->ev_att[sd]  |= bb_control;
         if (!(bb_control & Mask.away[sd]))
@@ -346,7 +346,7 @@ void cEngine::EvaluatePieces(POS *p, eData *e, int sd) {
     Add(e, sd, (Par.lines_weight * lines_mg)     / 100, (Par.lines_weight * lines_eg)     / 100);
     Add(e, sd, (Par.forward_weight * fwd_bonus[fwd_cnt] * fwd_weight) / 100, 0);
     Add(e, sd, (Par.outposts_weight * outpost) / 100);
-	Add(e, sd, (Par.center_weight * center_control) / 100, 0);
+    Add(e, sd, (Par.center_weight * center_control) / 100, 0);
 
     // King attack eval
 

--- a/sources/src/eval_draw.cpp
+++ b/sources/src/eval_draw.cpp
@@ -276,7 +276,7 @@ int cEngine::CheckmateHelper(POS *p) {
 
     int result = 0;
 
-	// KQ vs Kx: drive enemy king towards the edge
+    // KQ vs Kx: drive enemy king towards the edge
 
     if (p->cnt[WC][Q] > 0 && p->cnt[WC][P] == 0) {
         if (p->cnt[BC][Q] == 0 && p->cnt[BC][P] == 0 && p->cnt[BC][R] + p->cnt[BC][B] + p->cnt[BC][N] <= 1) {
@@ -298,7 +298,7 @@ int cEngine::CheckmateHelper(POS *p) {
         }
     }
 
-	// Weaker side has bare king (KQK, KRK, KBBK + bigger advantage
+    // Weaker side has bare king (KQK, KRK, KBBK + bigger advantage
 
     if (p->cnt[BC][P] + p->cnt[BC][N] + p->cnt[BC][B] + p->cnt[BC][R] + p->cnt[BC][Q] == 0) {
         if ((p->cnt[WC][Q] + p->cnt[WC][R] > 0) || p->cnt[WC][B] > 1) {
@@ -316,7 +316,7 @@ int cEngine::CheckmateHelper(POS *p) {
         }
     }
 
-	// KBN vs K specialized code
+    // KBN vs K specialized code
 
     if (p->cnt[WC][P] == 0
     &&  p->cnt[BC][P] == 0

--- a/sources/src/eval_patterns.cpp
+++ b/sources/src/eval_patterns.cpp
@@ -31,21 +31,21 @@ void cEngine::EvaluateBishopPatterns(POS *p, eData *e) {
         if (IsOnSq(p, WC, B, G8) && IsOnSq(p, BC, P, F7)) Add(e, WC, Par.values[B_TRAP_A2]);
 
         // white bishop blocked on its initial square by own pawn
-		// or returning to protect castled king
+        // or returning to protect castled king
 
-		if (IsOnSq(p, WC, B, C1)) {
-			if (IsOnSq(p, WC, P, D2) && (SqBb(D3) & OccBb(p))) 
-				Add(e, WC, Par.values[B_BLOCK], 0);
-			if (p->Kings(WC) & (SqBb(B1) | SqBb(A1) | SqBb(A2) ))
-				Add(e, WC, Par.values[B_RETURN], 0);
-		}
+        if (IsOnSq(p, WC, B, C1)) {
+            if (IsOnSq(p, WC, P, D2) && (SqBb(D3) & OccBb(p)))
+                Add(e, WC, Par.values[B_BLOCK], 0);
+            if (p->Kings(WC) & (SqBb(B1) | SqBb(A1) | SqBb(A2) ))
+                Add(e, WC, Par.values[B_RETURN], 0);
+        }
 
-		if (IsOnSq(p, WC, B, F1)) {
-			if ( IsOnSq(p, WC, P, E2) && (SqBb(E3) & OccBb(p)))
-			Add(e, WC, Par.values[B_BLOCK], 0);
-			if (p->Kings(WC) & (SqBb(G1) | SqBb(H1) | SqBb(H2)))
-				Add(e, WC, Par.values[B_RETURN], 0);
-		}
+        if (IsOnSq(p, WC, B, F1)) {
+            if ( IsOnSq(p, WC, P, E2) && (SqBb(E3) & OccBb(p)))
+            Add(e, WC, Par.values[B_BLOCK], 0);
+            if (p->Kings(WC) & (SqBb(G1) | SqBb(H1) | SqBb(H2)))
+                Add(e, WC, Par.values[B_RETURN], 0);
+        }
 
         // white bishop fianchettoed
 
@@ -76,21 +76,21 @@ void cEngine::EvaluateBishopPatterns(POS *p, eData *e) {
         if (IsOnSq(p, BC, B, G1) && IsOnSq(p, WC, P, F2)) Add(e, BC, Par.values[B_TRAP_A2]);
 
         // black bishop blocked on its initial square by own pawn
-		// or returning to protect castled king
+        // or returning to protect castled king
 
-		if (IsOnSq(p, BC, B, C8)) {
-			if (IsOnSq(p, BC, P, D7) && (SqBb(D6) & OccBb(p)))
-			    Add(e, BC, Par.values[B_BLOCK], 0);
-			if (p->Kings(BC) & (SqBb(B8) | SqBb(A8) | SqBb(A7)))
-				Add(e, BC, Par.values[B_RETURN], 0);
-		}
+        if (IsOnSq(p, BC, B, C8)) {
+            if (IsOnSq(p, BC, P, D7) && (SqBb(D6) & OccBb(p)))
+                Add(e, BC, Par.values[B_BLOCK], 0);
+            if (p->Kings(BC) & (SqBb(B8) | SqBb(A8) | SqBb(A7)))
+                Add(e, BC, Par.values[B_RETURN], 0);
+        }
 
-		if (IsOnSq(p, BC, B, F8)) {
-			if (IsOnSq(p, BC, P, E7) && (SqBb(E6) & OccBb(p)))
-				Add(e, BC, Par.values[B_BLOCK], 0);
-			if (p->Kings(BC) & (SqBb(G8) | SqBb(H8) | SqBb(H7)))
-				Add(e, BC, Par.values[B_RETURN], 0);
-		}
+        if (IsOnSq(p, BC, B, F8)) {
+            if (IsOnSq(p, BC, P, E7) && (SqBb(E6) & OccBb(p)))
+                Add(e, BC, Par.values[B_BLOCK], 0);
+            if (p->Kings(BC) & (SqBb(G8) | SqBb(H8) | SqBb(H7)))
+                Add(e, BC, Par.values[B_RETURN], 0);
+        }
 
         // black bishop fianchettoed
 

--- a/sources/src/mask.cpp
+++ b/sources/src/mask.cpp
@@ -17,26 +17,26 @@ If not, see <http://www.gnu.org/licenses/>.
 
 #include "rodent.h"
 
+// Own/enemy half of the board
+constexpr U64 cMask::home[2];
+constexpr U64 cMask::away[2];
+
+// Castling zones
+constexpr U64 cMask::ks_castle[2];
+constexpr U64 cMask::qs_castle[2];
+
+// Mask of squares with positive outpost score
+constexpr U64 cMask::outpost_map[2];
+
+// King side / queen side
+constexpr U64 cMask::k_side;
+constexpr U64 cMask::q_side;
+
+// Squares requiring bishop pat
+constexpr U64 cMask::wb_special;
+constexpr U64 cMask::bb_special;
+
 void cMask::Init() {
-
-    // Kingside/queenside
-
-    k_side = FILE_F_BB | FILE_G_BB | FILE_H_BB;
-    q_side = FILE_A_BB | FILE_B_BB | FILE_C_BB;
-
-    // Own/enemy half of the board
-
-    home[WC] = RANK_1_BB | RANK_2_BB | RANK_3_BB | RANK_4_BB;
-    home[BC] = RANK_8_BB | RANK_7_BB | RANK_6_BB | RANK_5_BB;
-    away[WC] = RANK_8_BB | RANK_7_BB | RANK_6_BB | RANK_5_BB;
-    away[BC] = RANK_1_BB | RANK_2_BB | RANK_3_BB | RANK_4_BB;
-
-    // Castling zones
-
-    qs_castle[WC] = SqBb(A1) | SqBb(B1) | SqBb(C1) | SqBb(A2) | SqBb(B2) | SqBb(C2);
-    qs_castle[BC] = SqBb(A8) | SqBb(B8) | SqBb(C8) | SqBb(A7) | SqBb(B7) | SqBb(C7);
-    ks_castle[WC] = SqBb(F1) | SqBb(G1) | SqBb(H1) | SqBb(F2) | SqBb(G2) | SqBb(H2);
-    ks_castle[BC] = SqBb(F8) | SqBb(G8) | SqBb(H8) | SqBb(F7) | SqBb(G7) | SqBb(H7);
 
     // Adjacent files (for isolated pawn detection)
 
@@ -64,19 +64,4 @@ void cMask::Init() {
         passed[BC][sq] = BB.FillSouthExcl(SqBb(sq));
         passed[BC][sq] |= BB.ShiftSideways(passed[BC][sq]);
     }
-
-    // Mask of squares with positive outpost score
-
-    outpost_map[WC] = bb_rel_rank[WC][RANK_4] | bb_rel_rank[WC][RANK_5] | bb_rel_rank[WC][RANK_6];
-    outpost_map[BC] = bb_rel_rank[BC][RANK_4] | bb_rel_rank[BC][RANK_5] | bb_rel_rank[BC][RANK_6];
-    outpost_map[WC] = outpost_map[WC] & bbNotA;
-    outpost_map[WC] = outpost_map[WC] & bbNotH;
-    outpost_map[BC] = outpost_map[WC] & bbNotA;
-    outpost_map[BC] = outpost_map[WC] & bbNotH;
-
-    // Squares requiring bishop pattern evaluation
-
-    wb_special = SqBb(A7) | SqBb(A6) | SqBb(B8) | SqBb(H7) | SqBb(H6) | SqBb(G8) | SqBb(C1) | SqBb(F1) | SqBb(G2) | SqBb(B2);
-    bb_special = SqBb(A2) | SqBb(A3) | SqBb(B1) | SqBb(H2) | SqBb(H3) | SqBb(G1) | SqBb(C8) | SqBb(F8) | SqBb(G7) | SqBb(B7);
-
 }

--- a/sources/src/params.cpp
+++ b/sources/src/params.cpp
@@ -131,7 +131,7 @@ void cParam::DefaultWeights() {
     shut_up = false;       // true suppresses displaying info currmove etc.
 
     // Attack and mobility weights that can be set independently for each side
-	// - the core of personality mechanism
+    // - the core of personality mechanism
 
     own_att_weight = 100;
     opp_att_weight = 100;
@@ -151,7 +151,7 @@ void cParam::DefaultWeights() {
     struct_weight = 100;
     shield_weight = 119;
     storm_weight = 99;
-	center_weight = 50;
+    center_weight = 50;
 
     // Pawn structure parameters
 
@@ -232,7 +232,7 @@ void cParam::DefaultWeights() {
     values[B_TOUCH] = 4;   // two bishops on adjacent squares
     values[B_OWN_P] = -3;  // own pawn on the square of own bishop's color
     values[B_OPP_P] = -1;  // enemy pawn on the square of own bishop's color
-	values[B_RETURN] = 10; // bishop returning to initial position after castling
+    values[B_RETURN] = 10; // bishop returning to initial position after castling
 
     // Rook parameters
 

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -547,18 +547,31 @@ extern cDistance Dist;
 class cMask {
   public:
     void Init();
-    U64 k_side;
-    U64 q_side;
-    U64 home[2];
-    U64 away[2];
-    U64 ks_castle[2];
-    U64 qs_castle[2];
-    U64 outpost_map[2];
-    U64 passed[2][64];
+
+    static constexpr U64 home[2] = { RANK_1_BB | RANK_2_BB | RANK_3_BB | RANK_4_BB,
+                                     RANK_8_BB | RANK_7_BB | RANK_6_BB | RANK_5_BB };
+    static constexpr U64 away[2] = { RANK_8_BB | RANK_7_BB | RANK_6_BB | RANK_5_BB,
+                                     RANK_1_BB | RANK_2_BB | RANK_3_BB | RANK_4_BB };
+
+    static constexpr U64 ks_castle[2] = { SqBb(F1) | SqBb(G1) | SqBb(H1) | SqBb(F2) | SqBb(G2) | SqBb(H2),
+                                          SqBb(F8) | SqBb(G8) | SqBb(H8) | SqBb(F7) | SqBb(G7) | SqBb(H7) };
+    static constexpr U64 qs_castle[2] = { SqBb(A1) | SqBb(B1) | SqBb(C1) | SqBb(A2) | SqBb(B2) | SqBb(C2),
+                                          SqBb(A8) | SqBb(B8) | SqBb(C8) | SqBb(A7) | SqBb(B7) | SqBb(C7) };
+
+    static constexpr U64 outpost_map[2] = { (bb_rel_rank[WC][RANK_4] | bb_rel_rank[WC][RANK_5] | bb_rel_rank[WC][RANK_6]) & bbNotA & bbNotH,
+                                            (bb_rel_rank[BC][RANK_4] | bb_rel_rank[BC][RANK_5] | bb_rel_rank[BC][RANK_6]) & bbNotA & bbNotH };
+
+    static constexpr U64 k_side = FILE_F_BB | FILE_G_BB | FILE_H_BB;
+    static constexpr U64 q_side = FILE_A_BB | FILE_B_BB | FILE_C_BB;
+
+    static constexpr U64 wb_special = SqBb(A7) | SqBb(A6) | SqBb(B8) | SqBb(H7) | SqBb(H6) | SqBb(G8) | SqBb(C1) | SqBb(F1) | SqBb(G2) | SqBb(B2);
+    static constexpr U64 bb_special = SqBb(A2) | SqBb(A3) | SqBb(B1) | SqBb(H2) | SqBb(H3) | SqBb(G1) | SqBb(C8) | SqBb(F8) | SqBb(G7) | SqBb(B7);
+
     U64 adjacent[8];
+    U64 passed[2][64];
     U64 supported[2][64];
-    U64 wb_special;
-    U64 bb_special;
+
+    static_assert(WC == 0 && BC == 1, "must be WC == 0 && BC == 1");
 };
 
 extern cMask Mask;

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -852,14 +852,14 @@ extern int tt_date;
 
 #if defined(_WIN32) || defined(_WIN64)
     #if defined(BOOKSPATH)
-        #define _BOOKSPATH MAKESTR(BOOKSPATH) L""
+        constexpr wchar_t _BOOKSPATH[] = MAKESTR(BOOKSPATH) L"";
     #else
-        #define _BOOKSPATH L"books\\"
+        constexpr wchar_t _BOOKSPATH[] = L"books\\";
     #endif
     #if defined(PERSONALITIESPATH)
-        #define _PERSONALITIESPATH MAKESTR(PERSONALITIESPATH) L""
+        constexpr wchar_t _PERSONALITIESPATH[] = MAKESTR(PERSONALITIESPATH) L"";
     #else
-        #define _PERSONALITIESPATH L"personalities\\"
+        constexpr wchar_t _PERSONALITIESPATH[] = L"personalities\\";
     #endif
     #define PrintOverrides() {}
     // change dir and return true on success
@@ -867,14 +867,14 @@ extern int tt_date;
     bool ChDir(const wchar_t *new_path);
 #else
     #if defined(BOOKSPATH)
-        #define _BOOKSPATH MAKESTR(BOOKSPATH) ""
+        constexpr char _BOOKSPATH[] = MAKESTR(BOOKSPATH) "";
     #else
-        #define _BOOKSPATH "books/"
+        constexpr char _BOOKSPATH[] = "books/";
     #endif
     #if defined(PERSONALITIESPATH)
-        #define _PERSONALITIESPATH MAKESTR(PERSONALITIESPATH) ""
+        constexpr char _PERSONALITIESPATH[] = MAKESTR(PERSONALITIESPATH) "";
     #else
-        #define _PERSONALITIESPATH "personalities/"
+        constexpr char _PERSONALITIESPATH[] = "personalities/";
     #endif
     void PrintOverrides();
     // change dir and return true on success

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -89,56 +89,56 @@ enum eSquare {
     NO_SQ
 };
 
-#define PHA_MG Q
-#define DEF_MG K
-#define PHA_EG P
-#define DEF_EG R
+constexpr int PHA_MG = Q;
+constexpr int DEF_MG = K;
+constexpr int PHA_EG = P;
+constexpr int DEF_EG = R;
 
-#define MAX_PLY         64
-#define MAX_MOVES       256
-#define INF             32767
-#define MATE            32000
-#define MAX_EVAL        29999
-#define MAX_HIST        (1 << 15)
+constexpr int MAX_PLY   = 64;
+constexpr int MAX_MOVES = 256;
+constexpr int INF       = 32767;
+constexpr int MATE      = 32000;
+constexpr int MAX_EVAL  = 29999;
+constexpr int MAX_HIST  = 1 << 15;
 
-#define RANK_1_BB       (U64)0x00000000000000FF
-#define RANK_2_BB       (U64)0x000000000000FF00
-#define RANK_3_BB       (U64)0x0000000000FF0000
-#define RANK_4_BB       (U64)0x00000000FF000000
-#define RANK_5_BB       (U64)0x000000FF00000000
-#define RANK_6_BB       (U64)0x0000FF0000000000
-#define RANK_7_BB       (U64)0x00FF000000000000
-#define RANK_8_BB       (U64)0xFF00000000000000
+constexpr U64 RANK_1_BB = 0x00000000000000FF;
+constexpr U64 RANK_2_BB = 0x000000000000FF00;
+constexpr U64 RANK_3_BB = 0x0000000000FF0000;
+constexpr U64 RANK_4_BB = 0x00000000FF000000;
+constexpr U64 RANK_5_BB = 0x000000FF00000000;
+constexpr U64 RANK_6_BB = 0x0000FF0000000000;
+constexpr U64 RANK_7_BB = 0x00FF000000000000;
+constexpr U64 RANK_8_BB = 0xFF00000000000000;
 
-#define FILE_A_BB       (U64)0x0101010101010101
-#define FILE_B_BB       (U64)0x0202020202020202
-#define FILE_C_BB       (U64)0x0404040404040404
-#define FILE_D_BB       (U64)0x0808080808080808
-#define FILE_E_BB       (U64)0x1010101010101010
-#define FILE_F_BB       (U64)0x2020202020202020
-#define FILE_G_BB       (U64)0x4040404040404040
-#define FILE_H_BB       (U64)0x8080808080808080
+constexpr U64 FILE_A_BB = 0x0101010101010101;
+constexpr U64 FILE_B_BB = 0x0202020202020202;
+constexpr U64 FILE_C_BB = 0x0404040404040404;
+constexpr U64 FILE_D_BB = 0x0808080808080808;
+constexpr U64 FILE_E_BB = 0x1010101010101010;
+constexpr U64 FILE_F_BB = 0x2020202020202020;
+constexpr U64 FILE_G_BB = 0x4040404040404040;
+constexpr U64 FILE_H_BB = 0x8080808080808080;
 
-#define DIAG_A1H8_BB    (U64)0x8040201008040201
-#define DIAG_A8H1_BB    (U64)0x0102040810204080
-#define DIAG_B8H2_BB    (U64)0x0204081020408000
+constexpr U64 DIAG_A1H8_BB = 0x8040201008040201;
+constexpr U64 DIAG_A8H1_BB = 0x0102040810204080;
+constexpr U64 DIAG_B8H2_BB = 0x0204081020408000;
 
 #define REL_SQ(sq,cl)   ( sq ^ (cl * 56) )
 #define RelSqBb(sq,cl)  ( SqBb(REL_SQ(sq,cl) ) )
 
-#define bbWhiteSq       (U64)0x55AA55AA55AA55AA
-#define bbBlackSq       (U64)0xAA55AA55AA55AA55
+constexpr U64 bbWhiteSq = 0x55AA55AA55AA55AA;
+constexpr U64 bbBlackSq = 0xAA55AA55AA55AA55;
 
-static const U64 bb_rel_rank[2][8] = {
+constexpr U64 bb_rel_rank[2][8] = {
     { RANK_1_BB, RANK_2_BB, RANK_3_BB, RANK_4_BB, RANK_5_BB, RANK_6_BB, RANK_7_BB, RANK_8_BB },
     { RANK_8_BB, RANK_7_BB, RANK_6_BB, RANK_5_BB, RANK_4_BB, RANK_3_BB, RANK_2_BB, RANK_1_BB }
 };
 
-static const U64 bb_central_file = FILE_C_BB | FILE_D_BB | FILE_E_BB | FILE_F_BB;
+constexpr U64 bb_central_file = FILE_C_BB | FILE_D_BB | FILE_E_BB | FILE_F_BB;
 
-#define SIDE_RANDOM     (~((U64)0))
+constexpr U64 SIDE_RANDOM = ~UINT64_C(0);
 
-#define START_POS       "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -"
+constexpr char START_POS[] = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -";
 
 #define SqBb(x)         ((U64)1 << (x))
 
@@ -246,8 +246,8 @@ template<typename T> constexpr const T& Min(const T& x, const T& y) { return x <
     #define FirstOne(x)     bit_table[(((x) & (~(x) + 1)) * (U64)0x0218A392CD3D5DBF) >> 58] // first "1" in a bitboard
 #endif
 
-#define bbNotA          (U64)0xfefefefefefefefe // ~FILE_A_BB
-#define bbNotH          (U64)0x7f7f7f7f7f7f7f7f // ~FILE_H_BB
+constexpr U64 bbNotA = ~FILE_A_BB; // 0xfefefefefefefefe
+constexpr U64 bbNotH = ~FILE_H_BB; // 0x7f7f7f7f7f7f7f7f
 
 #define ShiftNorth(x)   (x<<8)
 #define ShiftSouth(x)   (x>>8)
@@ -650,8 +650,8 @@ sInternalBook InternalBook;
 
 void CheckTimeout();
 
-#define EVAL_HASH_SIZE (512 * 512 / 4)
-#define PAWN_HASH_SIZE (512 * 512 / 4)
+constexpr int EVAL_HASH_SIZE = 512 * 512 / 4;
+constexpr int PAWN_HASH_SIZE = 512 * 512 / 4;
 
 class cEngine {
     sEvalHashEntry EvalTT[EVAL_HASH_SIZE];

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -491,9 +491,9 @@ class cParam {
     int storm_weight;
     int struct_weight;
     int passers_weight;
-	int center_weight;
-	int pawn_mass_weight;
-	int pawn_chains_weight;
+    int center_weight;
+    int pawn_mass_weight;
+    int pawn_chains_weight;
     int sd_att[2];
     int sd_mob[2];
     int mg_pst[2][6][64];
@@ -744,10 +744,10 @@ class cEngine {
 
     static const int razor_margin[];
     static const int fut_margin[];
-	static const int selective_depth;
-	static const int snp_depth;      // max depth at which static null move pruning is applied
-	static const int razor_depth;    // max depth at which razoring is applied
-	static const int fut_depth;      // max depth at which futility pruning is applied
+    static const int selective_depth;
+    static const int snp_depth;      // max depth at which static null move pruning is applied
+    static const int razor_depth;    // max depth at which razoring is applied
+    static const int fut_depth;      // max depth at which futility pruning is applied
     static int lmr_size[2][MAX_PLY][MAX_MOVES];
 
   public:

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -123,7 +123,7 @@ constexpr U64 DIAG_A1H8_BB = 0x8040201008040201;
 constexpr U64 DIAG_A8H1_BB = 0x0102040810204080;
 constexpr U64 DIAG_B8H2_BB = 0x0204081020408000;
 
-#define REL_SQ(sq,cl)   ( sq ^ (cl * 56) )
+#define REL_SQ(sq,cl)   ( (sq) ^ ((cl) * 56) )
 #define RelSqBb(sq,cl)  ( SqBb(REL_SQ(sq,cl) ) )
 
 constexpr U64 bbWhiteSq = 0x55AA55AA55AA55AA;
@@ -249,14 +249,14 @@ template<typename T> constexpr const T& Min(const T& x, const T& y) { return x <
 constexpr U64 bbNotA = ~FILE_A_BB; // 0xfefefefefefefefe
 constexpr U64 bbNotH = ~FILE_H_BB; // 0x7f7f7f7f7f7f7f7f
 
-#define ShiftNorth(x)   (x<<8)
-#define ShiftSouth(x)   (x>>8)
-#define ShiftWest(x)    ((x & bbNotA)>>1)
-#define ShiftEast(x)    ((x & bbNotH)<<1)
-#define ShiftNW(x)      ((x & bbNotA)<<7)
-#define ShiftNE(x)      ((x & bbNotH)<<9)
-#define ShiftSW(x)      ((x & bbNotA)>>9)
-#define ShiftSE(x)      ((x & bbNotH)>>7)
+#define ShiftNorth(x)   ((x)<<8)
+#define ShiftSouth(x)   ((x)>>8)
+#define ShiftWest(x)    (((x) & bbNotA)>>1)
+#define ShiftEast(x)    (((x) & bbNotH)<<1)
+#define ShiftNW(x)      (((x) & bbNotA)<<7)
+#define ShiftNE(x)      (((x) & bbNotH)<<9)
+#define ShiftSW(x)      (((x) & bbNotA)>>9)
+#define ShiftSE(x)      (((x) & bbNotH)>>7)
 
 //#define JustOne(bb)     ((bb) && !((bb) & ((bb)-1)))
 //#define MoreThanOne(bb) ((bb) & ((bb) - 1))

--- a/sources/src/uci_options.cpp
+++ b/sources/src/uci_options.cpp
@@ -490,19 +490,19 @@ void ParseSetoption(const char *ptr) {
         Glob.should_clear = true;
     } else if (strcmp(name, "minorup") == 0)                                 {
         Par.values[A_MIN] = atoi(value);
-		Par.InitMaterialTweaks();
+        Par.InitMaterialTweaks();
         Glob.should_clear = true;
     } else if (strcmp(name, "majorup") == 0)                                 {
         Par.values[A_MAJ] = atoi(value);
-		Par.InitMaterialTweaks();
+        Par.InitMaterialTweaks();
         Glob.should_clear = true;
     } else if (strcmp(name, "bothup") == 0)                                  {
         Par.values[A_ALL] = atoi(value);
-		Par.InitMaterialTweaks();
+        Par.InitMaterialTweaks();
         Glob.should_clear = true;
     } else if (strcmp(name, "twominors") == 0)                               {
         Par.values[A_TWO] = atoi(value);
-		Par.InitMaterialTweaks();
+        Par.InitMaterialTweaks();
         Glob.should_clear = true;
 
     // Here starts a block of non-eval options
@@ -593,13 +593,13 @@ void ReadPersonality(const char *fileName) {
     if (personalityFile == NULL)
         return;
 
-	// It is possible that user will attempt to load a personality of older Rodent version.
-	// There is nothing wrong with that, except that there will be some parameters missing.
-	// and there will be no way of telling whether previous personality used their default
-	// value or not. For that reason now that we found a personality file, we reset params
-	// to their default values.
+    // It is possible that user will attempt to load a personality of older Rodent version.
+    // There is nothing wrong with that, except that there will be some parameters missing.
+    // and there will be no way of telling whether previous personality used their default
+    // value or not. For that reason now that we found a personality file, we reset params
+    // to their default values.
 
-	Par.DefaultWeights();
+    Par.DefaultWeights();
 
     // Set flag in case we want to disable some options while reading personality from a file
 
@@ -639,7 +639,7 @@ void ReadPersonality(const char *fileName) {
             continue;
         }
 
-		// Personality files use the same syntax as UCI options parser (yes I have been lazy)
+        // Personality files use the same syntax as UCI options parser (yes I have been lazy)
 
         const char *ptr = ParseToken(line, token);
         if (strcmp(token, "setoption") == 0)


### PR DESCRIPTION
Unfortunately I'm not happy with my refactoring/modernizing attempts. It looks like even nowadays compilers still can't produce predictable good result using _inline_ or _constexpr_ functions instead of macros.

So I came with this smaller set of changes. Just `#define`s replaced with `constexpr`s and **cMask** is more "*const*y" now. I will definitely continue my efforts tho'.

Fixes #55.