### PR TITLE
we actually require c++14 compatible compiler

### DIFF
--- a/docs/changes-tmp.txt
+++ b/docs/changes-tmp.txt
@@ -1,6 +1,6 @@
 just to not forget user/builder visible changes
 
-0. RodentIII requires C++11 compatible compiler.
+0. RodentIII requires C++14 compatible compiler.
 
 1. polyglot books can be fully cached in memory, controlled by BOOK_IN_MEMORY_MB (default 16MB max), disabled by NO_BOOK_IN_MEMORY.
    if a book is loaded into memory RodentIII reports `success/m` otherwise `success/d`

--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -22,8 +22,8 @@ If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#if !(__cplusplus >= 201103L || _MSVC_LANG >= 201402)
-    #error Rodent requires C++11 compatible compiler.
+#if !(__cplusplus >= 201402L || _MSVC_LANG >= 201402L)
+    #error Rodent requires C++14 compatible compiler.
 #endif
 
 #pragma warning( disable : 4577 )

--- a/sources/src/uci.cpp
+++ b/sources/src/uci.cpp
@@ -23,7 +23,7 @@ If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef USE_THREADS
     #include <thread>
-    using namespace std;
+    using namespace std::literals::chrono_literals;
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)


### PR DESCRIPTION
We actually have been requiring c++14 compatible compiler for almost 5 months, since we introduced `std::make_unique`.