### PR TITLE
Support WinXP-compatible build for VS2017 in appveyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ build_script:
   - dir *.exe
   # pack exe's to 7z's and delete exe's
   - for %%i in (*.exe) do 7z a -sdel -bso0 %APPVEYOR_BUILD_FOLDER%\mingw-"%%~ni.7z" "%%i"
-  - buildme_vs2017.bat pgo
+  - buildme_vs2017.bat pgo winxp
   - dir *.exe
   # pack exe's to zip's and delete exe's
   - for %%i in (*.exe) do 7z a -sdel -bso0 %APPVEYOR_BUILD_FOLDER%\"%%~ni.zip" "%%i"

--- a/sources/buildme_vs2017.bat
+++ b/sources/buildme_vs2017.bat
@@ -4,7 +4,7 @@ setlocal
 
 set vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
 
-for /f "usebackq tokens=*" %%i in (`%vswhere% -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`%vswhere% -latest -property installationPath`) do (
   set InstallDir=%%i
 )
 

--- a/sources/buildme_vs2017.bat
+++ b/sources/buildme_vs2017.bat
@@ -10,6 +10,7 @@ for /f "usebackq tokens=*" %%i in (`%vswhere% -latest -property installationPath
 
 set EXENAME=RodentIII
 set PROF=%1
+set WXP=%2
 
 call "%InstallDir%\Common7\Tools\VsDevCmd.bat" -arch=x86
 
@@ -29,6 +30,25 @@ call :build
 
 set POPCNTDEF=/D NO_MM_POPCNT
 set ENAME="%EXENAME%_x64_noPOPCNT.exe"
+if not "%WXP%"=="winxp" goto :build
+call :build
+
+rem WINXP
+call "%InstallDir%\Common7\Tools\VsDevCmd.bat" -arch=x86
+
+set INCLUDE=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Include;%INCLUDE%
+set PATH=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Bin;%PATH%
+set LIB=%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.1A\Lib;%LIB%
+set CL=/D_USING_V110_SDK71_;%CL%
+set LINK=/SUBSYSTEM:CONSOLE,5.01 %LINK%
+
+set POPCNTDEF=
+set ENAME="%EXENAME%_x32_POPCNT_xp.exe"
+call :build
+
+set POPCNTDEF=/D NO_MM_POPCNT
+set ENAME="%EXENAME%_x32_noPOPCNT_xp.exe"
+rem WINXP
 
 :build
 


### PR DESCRIPTION
It kinda works right now, but I can't be sure for how long it will be the case. When it breaks then simple do
`git revert a5b0700002a8e84e7691b836c3b0efcc93861a37`.
It looks like **mingw**-builds are still *WinXP*-compatible for now.